### PR TITLE
Adding Daemon Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ SYNOPSIS
           Port-forwards to a lone port on the remote host
       -d, --daemon
           Run kpoof as a daemon
+      -k, --kill
+          Kills a kpoof command daemon, if running
 
 SEE ALSO
     kubectx(1), kubens(1), kex(1)

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ SYNOPSIS
           Port-forwards to a lone port on the remote host
       -d, --daemon
           Run kpoof as a daemon
-      -k, --kill
+      -k, --killd
           Kills a kpoof command daemon, if running
+      -a, --killd-all
+          Kills all running kpoof command daemons defined in $HOME/.kpoof/kpoofd
 
 SEE ALSO
     kubectx(1), kubens(1), kex(1)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ SYNOPSIS
           Show this help message
       -p, --port
           Port-forwards to a lone port on the remote host
+      -d, --daemon
+          Run kpoof as a daemon
 
 SEE ALSO
     kubectx(1), kubens(1), kex(1)

--- a/kpoof
+++ b/kpoof
@@ -204,6 +204,23 @@ daemon() {
 
   # Add to list of running daemons.
   echo $STRING >> ${DAEMONSFILE}
+
+  # Give the user initial output so they have immediate port-forwarding info
+  # even when daemonizing. However, it may take a short time for the kubectl
+  # port-forward command to write output to the logfile, so wait a reasonable
+  # amount of time (10 seconds total, at 1/2 second intervals).
+  for i in $(seq 1 20);
+  do
+    OUTPUT=$(cat ${LOGFILE})
+    if [ ! -z "$OUTPUT" ]; then
+      echo "${OUTPUT}"
+      echo 'When finished, stop this daemon process with kpoof -k, or stop all kubectl port-forward processes with kpoof -a'
+      exit 0
+    fi
+    echo 'Port forwarding is still pending. Waiting...'
+    sleep 0.5
+  done
+  echo "Port forwarding didn't resolve within 10 seconds"
 }
 
 initappdir() {

--- a/kpoof
+++ b/kpoof
@@ -7,6 +7,12 @@
 set -eou pipefail
 IFS=$'\n\t'
 
+NOW=$(date +"%F")
+NOWT=$(date +"%T")
+APPDIR="${HOME}"/.kpoof
+DAEMONSFILE="${APPDIR}"/kpoofd
+LOGFILE=${APPDIR}/kpoof-${NOW}-${NOWT}.log
+
 # We do this so the called script name variable is available in utility functions
 # below, in case of name change, brew alias, etc.
 SCRIPT=`basename ${BASH_SOURCE[0]}`
@@ -39,8 +45,10 @@ OPTIONS
         Port-forwards to a lone port on the remote host
     -d, --daemon
         Runs kpoof command as a daemon
-    -k, --kill
+    -k, --killd
         Kills a kpoof command daemon, if running
+    -a, --killd-all
+        Kills all running kpoof command daemons defined in $HOME/.kpoof/kpoofd
 
 SEE ALSO
     kubectx(1), kubens(1), kex(1)
@@ -126,30 +134,80 @@ port_sniff() {
 }
 
 po_pf() {
-  LOCAL_CHECK=$(port_check ${LOCAL_PORT:-$(port_sniff)})
-  # We eval so that the ampersand that may be returned by daemon() will start a
-  # process.
-  eval kubectl port-forward \
-    $(ns_param) $(po_select) $LOCAL_CHECK:${REMOTE_PORT:-$(port_sniff)} $(daemon)
+  local LOCAL_CHECK=$(port_check ${LOCAL_PORT:-$(port_sniff)})
+  local CMD="kubectl port-forward $(ns_param) $(po_select) $LOCAL_CHECK:${REMOTE_PORT:-$(port_sniff)}"
+  if [ ! -z "${KILLD:-}" ]; then killd ${CMD}; exit 0; fi
+  checkdaemon ${CMD}
 }
 
 po_pf_all() {
-  eval kubectl port-forward \
-  $(ns_param) $(po_select) $(port_x) $(daemon)
+  # Store CMD as an array, because passing strings with colons is unpredictable.
+  local CMD=(kubectl port-forward $(ns_param) $(po_select) $(port_x))
+  if [ ! -z "${KILLD:-}" ]; then killd "${CMD[@]}"; exit 0; fi
+  checkdaemon "${CMD[@]}"
 }
 
+# Requires daemon process CMD array as argument.
 killd() {
-  PID=$(ps -aef | grep 'kubectl port-forward' | grep -v grep | awk '{print $2}')
-  if [ ! -z "$PID" ]; then
-    kill -9 "$PID" || true
+  CMD=("$@")
+  STRING=$(printf ' %q' "${CMD[@]}"  | sed -e 's/^[[:space:]]*//')
+  local PID=$(ps -aef | grep $STRING | grep -v grep | awk '{print $2}')
+  if [ ! -z "${PID}" ]; then
+    kill -9 ${PID} || true
+  fi
+
+  # Remove CMD entry from daemon file.
+  local TMPFILE="${APPDIR}"/kpoofd.tmp
+  if [ -f $DAEMONSFILE ]; then
+    awk -v cmd=$STRING '$0!=cmd {print $0}' $DAEMONSFILE > $TMPFILE && mv $TMPFILE $DAEMONSFILE
   fi
 }
 
-daemon() {
-  killd
-  if [ ! -z "${DAEMON:-}" ]; then
-    echo '> kpoof_daemon_out 2>&1 &'
+killdall() {
+  if [ -f $DAEMONSFILE ]; then
+    while read CMD;
+    do
+      killd ${CMD}
+    done < $DAEMONSFILE
+    rm $DAEMONSFILE
   fi
+}
+
+# Requires daemon process CMD array as argument.
+checkdaemon() {
+  CMD=("$@")
+  if [ ! -z "${DAEMON:-}" ]; then
+    daemon "${CMD[@]}"
+  else
+    "${CMD[@]}"
+  fi
+}
+
+# Requires daemon process CMD array as argument.
+# Each daemon CMD (see `man ps`) consists of a unique `kubectl port-forward`
+# command string, represented in this argument as an array.
+daemon() {
+  CMD=("$@")
+  STRING=$(printf ' %q' "${CMD[@]}"  | sed -e 's/^[[:space:]]*//')
+  # Always kill any running version of this exact process to avoid port-forward
+  # conflicts.
+  # Note that we could alternatively check whether the process is already
+  # running, and if so, not bother killing/restarting the daemon. owever, if the
+  # earlier running process is running but no longer works, then the user would
+  # need to `kpoof -k` to kill it and then `kpoof -d` to start it again. Since
+  # the port-forward process is quick to both kill and start, we do it for the
+  # user automatically to save manual checking and frustration.
+  killd "${CMD[@]}"
+
+  # Start daemon.
+  "${CMD[@]}" > ${LOGFILE} 2>&1 &
+
+  # Add to list of running daemons.
+  echo $STRING >> ${DAEMONSFILE}
+}
+
+initappdir() {
+  mkdir -p ${APPDIR}
 }
 
 # Transform long options to short ones. Sick trick.
@@ -160,17 +218,19 @@ for arg in "$@"; do
     "--help")       set -- "$@" "-h" ;;
     "--port")       set -- "$@" "-p" ;;
     "--daemon")     set -- "$@" "-d" ;;
-    "--kill")       set -- "$@" "-k" ;;
+    "--killd")      set -- "$@" "-k" ;;
+    "--killd-all")  set -- "$@" "-a" ;;
     *)              set -- "$@" "$arg"
   esac
 done
 
-while getopts :phdk OPT; do
+while getopts :phdka OPT; do
   case $OPT in
     h ) HELP=true;;
     p ) PORT=true;;
     d ) DAEMON=true;;
-    k ) KILL=true;;
+    k ) KILLD=true;;
+    a ) KILLDALL=true;;
     \?) echo "Unknown option: -$OPTARG" >&2; exit 1;;
     : ) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
   esac
@@ -180,9 +240,10 @@ shift $((OPTIND-1))
 # Help and port-forward should not happen simultaneously, so elif.
 if [[ ${HELP:-} == 'true' ]]; then
   usage; exit 0
-elif [[ ${KILL:-} == 'true' ]]; then
-  killd; exit 0
+elif [[ ${KILLDALL:-} == 'true' ]]; then
+  killdall; exit 0
 else
+  initappdir
   ns=$(ns_current)
   echo "Namespace? (default ${ns:-default}):"; ns_number_list; read NS;
   echo 'Pod number? (default 1):'; po_number_list; read POD;

--- a/kpoof
+++ b/kpoof
@@ -38,7 +38,9 @@ OPTIONS
     -p, --port
         Port-forwards to a lone port on the remote host
     -d, --daemon
-        Run kpoof as a daemon
+        Runs kpoof command as a daemon
+    -k, --kill
+        Kills a kpoof command daemon, if running
 
 SEE ALSO
     kubectx(1), kubens(1), kex(1)
@@ -125,24 +127,29 @@ port_sniff() {
 
 po_pf() {
   LOCAL_CHECK=$(port_check ${LOCAL_PORT:-$(port_sniff)})
-  kubectl port-forward \
-    $(ns_param) $(po_select) $LOCAL_CHECK:${REMOTE_PORT:-$(port_sniff)}
+  # We eval so that the ampersand that may be returned by daemon() will start a
+  # process.
+  eval kubectl port-forward \
+    $(ns_param) $(po_select) $LOCAL_CHECK:${REMOTE_PORT:-$(port_sniff)} $(daemon)
 }
 
 po_pf_all() {
-    kubectl port-forward \
-    $(ns_param) $(po_select) $(port_x)
+  eval kubectl port-forward \
+  $(ns_param) $(po_select) $(port_x) $(daemon)
 }
 
-po_pf_daemon() {
-  LOCAL_CHECK=$(port_check ${LOCAL_PORT:-$(port_sniff)})
-  kubectl port-forward \
-    $(ns_param) $(po_select) $LOCAL_CHECK:${REMOTE_PORT:-$(port_sniff)} >kpoof-output.txt 2>&1 < /dev/null &
+killd() {
+  PID=$(ps -aef | grep 'kubectl port-forward' | grep -v grep | awk '{print $2}')
+  if [ ! -z "$PID" ]; then
+    kill -9 "$PID" || true
+  fi
 }
 
-po_pf_daemon_all() {
-    kubectl port-forward \
-    $(ns_param) $(po_select) $(port_x) >kpoof-output.txt 2>&1 < /dev/null &
+daemon() {
+  killd
+  if [ ! -z "${DAEMON:-}" ]; then
+    echo '> kpoof_daemon_out 2>&1 &'
+  fi
 }
 
 # Transform long options to short ones. Sick trick.
@@ -153,15 +160,17 @@ for arg in "$@"; do
     "--help")       set -- "$@" "-h" ;;
     "--port")       set -- "$@" "-p" ;;
     "--daemon")     set -- "$@" "-d" ;;
+    "--kill")       set -- "$@" "-k" ;;
     *)              set -- "$@" "$arg"
   esac
 done
 
-while getopts :phd OPT; do
+while getopts :phdk OPT; do
   case $OPT in
     h ) HELP=true;;
     p ) PORT=true;;
     d ) DAEMON=true;;
+    k ) KILL=true;;
     \?) echo "Unknown option: -$OPTARG" >&2; exit 1;;
     : ) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
   esac
@@ -171,6 +180,8 @@ shift $((OPTIND-1))
 # Help and port-forward should not happen simultaneously, so elif.
 if [[ ${HELP:-} == 'true' ]]; then
   usage; exit 0
+elif [[ ${KILL:-} == 'true' ]]; then
+  killd; exit 0
 else
   ns=$(ns_current)
   echo "Namespace? (default ${ns:-default}):"; ns_number_list; read NS;
@@ -179,16 +190,8 @@ else
   if [[ ${PORT:-} == 'true' ]]; then
     echo 'Remote port number? (default 1):'; port_number_list; read REMOTE_PORT;
     echo "Local port number? (defaults to $(port_sniff)):"; read LOCAL_PORT;
-    if [[ ${DAEMON:-} == 'true' ]]; then
-      po_pf_daemon
-    else
-      po_pf
-    fi
+    po_pf
   else
-    if [[ ${DAEMON:-} == 'true' ]]; then
-      po_pf_daemon_all
-    else
-      po_pf_all
-    fi
+    po_pf_all
   fi
 fi

--- a/kpoof
+++ b/kpoof
@@ -37,6 +37,8 @@ OPTIONS
         Show this help message
     -p, --port
         Port-forwards to a lone port on the remote host
+    -d, --daemon
+        Run kpoof as a daemon
 
 SEE ALSO
     kubectx(1), kubens(1), kex(1)
@@ -132,21 +134,34 @@ po_pf_all() {
     $(ns_param) $(po_select) $(port_x)
 }
 
+po_pf_daemon() {
+  LOCAL_CHECK=$(port_check ${LOCAL_PORT:-$(port_sniff)})
+  kubectl port-forward \
+    $(ns_param) $(po_select) $LOCAL_CHECK:${REMOTE_PORT:-$(port_sniff)} >kpoof-output.txt 2>&1 < /dev/null &
+}
+
+po_pf_daemon_all() {
+    kubectl port-forward \
+    $(ns_param) $(po_select) $(port_x) >kpoof-output.txt 2>&1 < /dev/null &
+}
+
 # Transform long options to short ones. Sick trick.
 # http://stackoverflow.com/a/30026641/4096495
 for arg in "$@"; do
   shift
   case "$arg" in
     "--help")       set -- "$@" "-h" ;;
-    "--port")        set -- "$@" "-p" ;;
+    "--port")       set -- "$@" "-p" ;;
+    "--daemon")     set -- "$@" "-d" ;;
     *)              set -- "$@" "$arg"
   esac
 done
 
-while getopts :ph OPT; do
+while getopts :phd OPT; do
   case $OPT in
     h ) HELP=true;;
     p ) PORT=true;;
+    d ) DAEMON=true;;
     \?) echo "Unknown option: -$OPTARG" >&2; exit 1;;
     : ) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
   esac
@@ -164,8 +179,16 @@ else
   if [[ ${PORT:-} == 'true' ]]; then
     echo 'Remote port number? (default 1):'; port_number_list; read REMOTE_PORT;
     echo "Local port number? (defaults to $(port_sniff)):"; read LOCAL_PORT;
-    po_pf
+    if [[ ${DAEMON:-} == 'true' ]]; then
+      po_pf_daemon
+    else
+      po_pf
+    fi
   else
-    po_pf_all
+    if [[ ${DAEMON:-} == 'true' ]]; then
+      po_pf_daemon_all
+    else
+      po_pf_all
+    fi
   fi
 fi


### PR DESCRIPTION
- Addresses Issue #9.
- Adding 'd' 'daemon' flag to run kpoof as a daemon.
- Daemon output is redirected to a local file named 'kpoof-output.txt'